### PR TITLE
Always display days, update current URL with selected version

### DIFF
--- a/main.js
+++ b/main.js
@@ -71,20 +71,12 @@ let versionClick = function(id) {
   let years = Math.floor(days / 365);
   let text = "";
 
-  if (years === 0) {
-    days = Math.floor(days);
-    if (days === 1) {
-      text = days + " day";
-    } else {
-      text = days + " days";
-    }
-  } else {
-    if (years === 1) {
-      text = "over " + years + " year";
-    } else {
-      text = "over " + years + " years";
-    }
+  if (years !== 0) {
+    text = years + (years === 1 ? " year, " : " years, ")
   }
+
+  days = Math.floor(days) % 365;
+  text += days + (days === 1 ? " day" : " days")
 
   $("#version").text(id);
   $("#versions-behind").text(arr[0] + " version" + ((arr[0] !== 1) ? "s" : ""));
@@ -93,7 +85,7 @@ let versionClick = function(id) {
 };
 
 $(document).ready(function() {
-  Object.keys(versioninfo).forEach(value => $("#nav-mobile").append(`<li><a class="sidenav-close waves-effect" id="${value}">${value}</a></li>`));
+  Object.keys(versioninfo).forEach(value => $("#nav-mobile").append(`<li><a class="sidenav-close waves-effect" href="#${value}" id="${value}">${value}</a></li>`));
 
   let hash = $(location).attr("hash").substr(1);
   


### PR DESCRIPTION
Changes:
 - Always display the count of days since that version's release. Previously only "over X years" were displayed if the count of days exceeded 365. This PR changes that so "X years, Y days" gets displayed instead.
 - Update the current URL when a version is selected, so that this copying and then opening that URL takes you to the selected version. No need to manually add `#1.8.8` at the end of the URL from now on!

Issues:
 - Leap years are still not taken into account.